### PR TITLE
chore: uses setup-node across builds

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: 'npm'
-      - run: npm install --ignore-engines
+      - run: npm ci
       - run: npm run build
 
   lint:
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: 'npm'
+      - run: npm ci
       - run: npm run lint
 
   release:
@@ -37,4 +38,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: 'npm'
+      - run: npm ci
       - run: npm run semantic-release

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -14,37 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: cache
-        uses: actions/cache@v3
-        with:
-          path: ./node_modules
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - uses: actions/setup-node@v3
       - run: npm install --ignore-engines
       - run: npm run build
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: node_modules
-      #     path: ./node_modules
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: cache
-        uses: actions/cache@v3
-        with:
-          path: ./node_modules
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - uses: actions/setup-node@v3
       - run: npm run lint
 
   release:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v2
-      - id: cache
-        uses: actions/cache@v2
-        with:
-          path: ./node_modules
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
       - run: npm run semantic-release

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          cache: 'npm'
       - run: npm install --ignore-engines
       - run: npm run build
 
@@ -23,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          cache: 'npm'
       - run: npm run lint
 
   release:
@@ -31,4 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          cache: 'npm'
       - run: npm run semantic-release


### PR DESCRIPTION
setup-node action takes care of caching already
