### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <a href="https://www.npmjs.org/package/snyk-or-snick"><img src="https://badgen.net/npm/v/snyk-or-snick" alt="npm version"/></a>
   <a href="https://www.npmjs.org/package/snyk-or-snick"><img src="https://badgen.net/npm/license/snyk-or-snick" alt="license"/></a>
   <a href="https://github.com/lirantal/snyk-or-snick/actions/workflows/main.yml"><img src="https://github.com/lirantal/snyk-or-snick/actions/workflows/main.yml/badge.svg" alt="build"/></a>
-  <a href="https://snyk.io/test/github/lirantal/snyk-or-snick"><img src="https://snyk.io/test/github/lirantal/snyk-or-snick/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.