### PR TITLE
fix: pin CI status badge to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://www.npmjs.org/package/snyk-or-snick"><img src="https://badgen.net/npm/v/snyk-or-snick" alt="npm version"/></a>
   <a href="https://www.npmjs.org/package/snyk-or-snick"><img src="https://badgen.net/npm/license/snyk-or-snick" alt="license"/></a>
-  <a href="https://github.com/lirantal/snyk-or-snick/actions/workflows/main.yml"><img src="https://github.com/lirantal/snyk-or-snick/actions/workflows/main.yml/badge.svg" alt="build and release ci"/></a>
+  <a href="https://github.com/lirantal/snyk-or-snick/actions/workflows/main.yml"><img src="https://github.com/lirantal/snyk-or-snick/actions/workflows/main.yml/badge.svg?branch=master" alt="build and release ci"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>
 


### PR DESCRIPTION
The CI status badge in the README points to the workflow URL without a branch query parameter, which can show the status of any branch (e.g. PR runs) rather than the default branch. Pinning the badge to the repository default branch so it consistently reflects mainline CI.